### PR TITLE
Fix anchor when direction is .top & width != height

### DIFF
--- a/Source/AnchorView.swift
+++ b/Source/AnchorView.swift
@@ -34,7 +34,7 @@ class AnchorView: UIView {
         case .top: //
             context.move(to: CGPoint(x: rect.minX, y: rect.minY))
             context.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
-            context.addLine(to: CGPoint(x: (rect.maxX / 2.0), y: rect.maxX))
+            context.addLine(to: CGPoint(x: (rect.maxX / 2.0), y: rect.maxY))
         case .bottom: // ^
             context.move(to: CGPoint(x: rect.minX, y: rect.maxY))
             context.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))


### PR DESCRIPTION
There's a minor typo here. The y coordinate of this point is maxY, not maxX.  It's easy to miss if anchorView width = size. You can see the issue if you create an anchor view with width != height. e.g. 24, 10.